### PR TITLE
:bug: set Dockerfile to jdk 21

### DIFF
--- a/refarch-gateway/Dockerfile
+++ b/refarch-gateway/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17:latest
+FROM registry.access.redhat.com/ubi9/openjdk-21:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar


### PR DESCRIPTION
**Description**

Fix Dockerfile wrong jdk version. Set it to 21.

Bug introduced with #16 
