### PR TITLE
:lock: security allow actuator probes

### DIFF
--- a/refarch-gateway/src/main/java/de.muenchen.oss.refarch.gateway/configuration/SecurityConfiguration.java
+++ b/refarch-gateway/src/main/java/de.muenchen.oss.refarch.gateway/configuration/SecurityConfiguration.java
@@ -78,6 +78,8 @@ public class SecurityConfiguration {
                             .pathMatchers(LOGOUT_SUCCESS_URL).permitAll()
                             .pathMatchers("/api/*/info",
                                     "/actuator/health",
+                                    "/actuator/health/liveness",
+                                    "/actuator/health/readiness",
                                     "/actuator/info",
                                     "/actuator/metrics")
                             .permitAll()

--- a/refarch-gateway/src/main/resources/application.yml
+++ b/refarch-gateway/src/main/resources/application.yml
@@ -54,7 +54,7 @@ management:
     enabled-by-default: false
     web:
       exposure:
-        include: health, info, prometheus, livenessstate, readinessstate
+        include: health, info, prometheus, livenessState, readinessState
       path-mapping:
         prometheus: metrics
   endpoint:

--- a/refarch-gateway/src/test/java/de.muenchen.oss.refarch.gateway/configuration/SecurityConfigurationTest.java
+++ b/refarch-gateway/src/test/java/de.muenchen.oss.refarch.gateway/configuration/SecurityConfigurationTest.java
@@ -20,7 +20,6 @@ public class SecurityConfigurationTest {
 
     @Test
     void accessSecuredResourceRootThenUnauthorized() {
-        // api.get().uri("/").exchange().expectStatus().isUnauthorized();
         // 302 is returned instead of 401 because auf cookie session
         api.get().uri("/").exchange().expectStatus().isFound();
     }

--- a/refarch-gateway/src/test/java/de.muenchen.oss.refarch.gateway/configuration/SecurityConfigurationTest.java
+++ b/refarch-gateway/src/test/java/de.muenchen.oss.refarch.gateway/configuration/SecurityConfigurationTest.java
@@ -1,0 +1,57 @@
+package de.muenchen.oss.refarch.gateway.configuration;
+
+import static de.muenchen.oss.refarch.gateway.TestConstants.SPRING_TEST_PROFILE;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@AutoConfigureObservability
+@ActiveProfiles(profiles = { SPRING_TEST_PROFILE })
+public class SecurityConfigurationTest {
+    @Autowired
+    WebTestClient api;
+
+    @Test
+    void accessSecuredResourceRootThenUnauthorized() {
+        // api.get().uri("/").exchange().expectStatus().isUnauthorized();
+        // 302 is returned instead of 401 because auf cookie session
+        api.get().uri("/").exchange().expectStatus().isFound();
+    }
+
+    @Test
+    void accessSecuredResourceClientsThenUnauthorized() {
+        api.get().uri("/clients/test").exchange().expectStatus().isUnauthorized();
+    }
+
+    @Test
+    void accessUnsecuredResourceActuatorHealthThenOk() {
+        api.get().uri("/actuator/health").exchange().expectStatus().isOk();
+    }
+
+    @Test
+    void accessUnsecuredResourceActuatorHealthLivenessThenOk() {
+        api.get().uri("/actuator/health/liveness").exchange().expectStatus().isOk();
+    }
+
+    @Test
+    void accessUnsecuredResourceActuatorHealthReadinessThenOk() {
+        api.get().uri("/actuator/health/readiness").exchange().expectStatus().isOk();
+    }
+
+    @Test
+    void accessUnsecuredResourceActuatorInfoThenOk() {
+        api.get().uri("/actuator/info").exchange().expectStatus().isOk();
+    }
+
+    @Test
+    void accessUnsecuredResourceActuatorMetricsThenOk() {
+        api.get().uri("/actuator/metrics").exchange().expectStatus().isOk();
+    }
+}


### PR DESCRIPTION
**Description**

Permit actuator probe endpoints for deployment health checks.

Required for #23 

Closes #37