### PR TITLE
:construction_worker: rm admin as default codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # These owners will be the default owners for everything in the repo.
-* @it-at-m/refarch-admin @it-at-m/refarch-maintainer
+* @it-at-m/refarch-maintainer
 
 # Protect CODEOWNERS file itself against modification
 /.github/CODEOWNERS @it-at-m/refarch-admin


### PR DESCRIPTION
**Description**

Rm admins as codeowners from all files as there could be admins which are not really contributing to projects.
I.e. for configuring security ...

See https://github.com/it-at-m/refarch-templates/pull/132
