### PR TITLE
:construction_worker: use jdk runtime image

### DIFF
--- a/refarch-gateway/Dockerfile
+++ b/refarch-gateway/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/ubi9/openjdk-21:latest
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar

--- a/refarch-integrations/refarch-s3-integration/refarch-s3-integration-service/Dockerfile
+++ b/refarch-integrations/refarch-s3-integration/refarch-s3-integration-service/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/ubi9/openjdk-21:latest
+FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:latest
 
 COPY target/*.jar /deployments/spring-boot-application.jar


### PR DESCRIPTION
**Description**

Use smaller jdk runtime image as suggested in #34 
