### PR TITLE
Maint/99 maintenance change development stack docker image versions to pinned versions instead of latest

### DIFF
--- a/stack/docker-compose-refarch-base.yml
+++ b/stack/docker-compose-refarch-base.yml
@@ -1,6 +1,6 @@
 # copy of https://github.com/it-at-m/refarch-templates/blob/main/stack/docker-compose.yml
 
-name: default-services
+name: refarch-stack
 
 services:
   postgres:

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -3,7 +3,7 @@ name: refarch-stack
 services:
   # s3
   minio:
-    image: quay.io/minio/minio:latest
+    image: quay.io/minio/minio:RELEASE.2024-08-17T01-24-54Z
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: minio
@@ -22,7 +22,7 @@ services:
       - no-new-privileges:true
 
   init-minio:
-    image: minio/mc
+    image: minio/mc:RELEASE.2024-08-17T11-33-50Z
     depends_on:
       - minio
     entrypoint: >
@@ -37,7 +37,7 @@ services:
 
   # mail
   mailpit:
-    image: axllent/mailpit:latest
+    image: axllent/mailpit:v1.20.2
     ports:
       - '1025:1025' # smtp server
       - '8025:8025' # ui

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -1,8 +1,9 @@
-name: refarch-stack
+name: refarch-extended-stack
 
 services:
   # s3
   minio:
+    container_name: minio
     image: quay.io/minio/minio:RELEASE.2024-08-17T01-24-54Z
     command: server /data --console-address ":9001"
     environment:
@@ -22,6 +23,7 @@ services:
       - no-new-privileges:true
 
   init-minio:
+    container_name: init-minio
     image: minio/mc:RELEASE.2024-08-17T11-33-50Z
     depends_on:
       - minio
@@ -37,6 +39,7 @@ services:
 
   # mail
   mailpit:
+    container_name: mailpit
     image: axllent/mailpit:v1.20.2
     ports:
       - '1025:1025' # smtp server


### PR DESCRIPTION
**Description**
- Pinned versions of docker images inside the stack
- Added missing container names
- Renamed docker stacks to differentiate between extended and base stack

**Reference**
Issues #99

**Additional Info**
Skipped pinning image versions in `Dockerfile` files because of #100
