### PR TITLE
Bug/stack rm container names and restart policy

### DIFF
--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       - "8100:8100"
     networks:
       - keycloak
-    restart: &restart-policy on-failure:3
     healthcheck: &healthcheck
       test: ["CMD-SHELL",  "curl http://localhost:8100/auth/health/live"]
       interval: 30s
@@ -40,7 +39,6 @@ services:
       - POSTGRES_PASSWORD=keycloak-secret
     networks:
       - keycloak
-    restart: *restart-policy
     healthcheck:
       <<: *healthcheck
       test: [ "CMD-SHELL", "pg_isready -d keycloak -U keycloak-user" ]
@@ -76,7 +74,6 @@ services:
       - ./minio:/data
     networks:
       - internal
-    restart: *restart-policy
     healthcheck:
       <<: *healthcheck
       test: [ "CMD-SHELL",  "curl http://localhost:9000/minio/health/live" ]
@@ -102,7 +99,6 @@ services:
     ports:
       - '1025:1025' # SMTP Server
       - '8025:8025' # UI
-    restart: *restart-policy
     security_opt: *security_settings
 
 networks:

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -3,7 +3,6 @@ name: refarch-development-stack
 services:
   # === Keycloak ===
   keycloak:
-    container_name: keycloak
     image: quay.io/keycloak/keycloak:20.0.5@sha256:054ef67eb7dae0129bbb9eb0e0797fd2392cd6d135094a6063ae7ff7773ef81f
     command:
       - start-dev --http-relative-path /auth
@@ -34,7 +33,6 @@ services:
       - no-new-privileges:true
 
   db-postgres-keycloak:
-    container_name: db-postgres-keycloak
     image: postgres:16.4-alpine3.20@sha256:d898b0b78a2627cb4ee63464a14efc9d296884f1b28c841b0ab7d7c42f1fffdf
     environment:
       - POSTGRES_DB=keycloak
@@ -49,7 +47,6 @@ services:
     security_opt: *security_settings
 
   init-keycloak:
-    container_name: init-keycloak
     image: klg71/keycloakmigration:0.2.69@sha256:66474865869f4dc11763e62e9722a62bd3351161d148547c3620f71e6809e95a
     depends_on:
       - keycloak
@@ -67,7 +64,6 @@ services:
 
   # === S3 ===
   minio:
-    container_name: minio
     image: quay.io/minio/minio:RELEASE.2024-08-17T01-24-54Z@sha256:6f23072e3e222e64fe6f86b31a7f7aca971e5129e55cbccef649b109b8e651a1
     command: server /data --console-address ":9001"
     environment:
@@ -87,7 +83,6 @@ services:
     security_opt: *security_settings
 
   init-minio:
-    container_name: init-minio
     image: minio/mc:RELEASE.2024-08-17T11-33-50Z@sha256:87382ad79da9f464a444aab607b3db9251c7fe7d1bfda0eb86cbacee2ca2b564
     depends_on:
       - minio
@@ -103,7 +98,6 @@ services:
 
   # === Mail ===
   mailpit:
-    container_name: mailpit
     image: axllent/mailpit:v1.20.5@sha256:cd75e91719cace4e3100eab9f848ecf2ecdd7f4db01e1573a0114769dad4ba2e
     ports:
       - '1025:1025' # SMTP Server


### PR DESCRIPTION
**Description**

- Rm container names to prevent naming collision with refarch-templates on startup.
- Rm restart policy to prevent auto startup

**Reference**

Issue https://github.com/it-at-m/refarch-templates/issues/309
