### PR TITLE
:bug: gateway fix hazelcast properties

### DIFF
--- a/refarch-gateway/pom.xml
+++ b/refarch-gateway/pom.xml
@@ -142,6 +142,13 @@
             <artifactId>spring-cloud-starter-contract-stub-runner</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Other -->
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>${spotbugs-annotations.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -275,7 +282,6 @@
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs-maven-plugin.version}</version>
                 <configuration>
-                    <excludeBugsFile>../shared-files/spotbugs-excludes.xml</excludeBugsFile>
                     <effort>Max</effort>
                     <plugins>
                         <plugin>

--- a/refarch-gateway/pom.xml
+++ b/refarch-gateway/pom.xml
@@ -275,6 +275,7 @@
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>${spotbugs-maven-plugin.version}</version>
                 <configuration>
+                    <excludeBugsFile>../shared-files/spotbugs-excludes.xml</excludeBugsFile>
                     <effort>Max</effort>
                     <plugins>
                         <plugin>

--- a/refarch-gateway/src/main/java/de/muenchen/refarch/gateway/configuration/HazelcastProperties.java
+++ b/refarch-gateway/src/main/java/de/muenchen/refarch/gateway/configuration/HazelcastProperties.java
@@ -5,7 +5,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
 @ConfigurationProperties("refarch.hazelcast")
-@SuppressWarnings("PMD.ImmutableField")
 public class HazelcastProperties {
     /**
      * Name of the hazelcast cluster.

--- a/refarch-gateway/src/main/java/de/muenchen/refarch/gateway/configuration/HazelcastProperties.java
+++ b/refarch-gateway/src/main/java/de/muenchen/refarch/gateway/configuration/HazelcastProperties.java
@@ -1,13 +1,9 @@
 package de.muenchen.refarch.gateway.configuration;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@Getter
-@RequiredArgsConstructor
-@AllArgsConstructor
+@Data
 @ConfigurationProperties("refarch.hazelcast")
 @SuppressWarnings("PMD.ImmutableField")
 public class HazelcastProperties {

--- a/refarch-gateway/src/main/java/de/muenchen/refarch/gateway/configuration/WebSessionHazelcastConfiguration.java
+++ b/refarch-gateway/src/main/java/de/muenchen/refarch/gateway/configuration/WebSessionHazelcastConfiguration.java
@@ -8,6 +8,7 @@ import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,6 +31,7 @@ import org.springframework.session.hazelcast.HazelcastIndexedSessionRepository;
 @EnableSpringWebSession
 @Profile({ "hazelcast-local", "hazelcast-k8s" })
 @RequiredArgsConstructor
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 public class WebSessionHazelcastConfiguration {
 
     private final HazelcastProperties hazelcastProperties;

--- a/shared-files/spotbugs-excludes.xml
+++ b/shared-files/spotbugs-excludes.xml
@@ -1,0 +1,7 @@
+<FindBugsFilter>
+    <Match>
+        <Class name="*"/> <!-- You can specify a specific class name if needed -->
+        <Method name="*"/> <!-- You can specify a specific method name if needed -->
+        <Bug code="EI_EXPOSE_REP2"/>
+    </Match>
+</FindBugsFilter>

--- a/shared-files/spotbugs-excludes.xml
+++ b/shared-files/spotbugs-excludes.xml
@@ -1,7 +1,0 @@
-<FindBugsFilter>
-    <Match>
-        <Class name="*"/> <!-- You can specify a specific class name if needed -->
-        <Method name="*"/> <!-- You can specify a specific method name if needed -->
-        <Bug code="EI_EXPOSE_REP2"/>
-    </Match>
-</FindBugsFilter>


### PR DESCRIPTION
**Description**

Gateway fix missing setter for Hazelcast properties.

```
***************************
APPLICATION FAILED TO START
***************************

Description:

Failed to bind properties under 'refarch.hazelcast' to de.muenchen.refarch.gateway.configuration.HazelcastProperties:

    Property: refarch.hazelcast.service-name
    Value: "refarch-gateway-tmn8mmqgaa"
    Origin: System Environment Property "REFARCH_HAZELCAST_SERVICENAME"
    Reason: java.lang.IllegalStateException: No setter found for property: service-name

Action:

Update your application's configuration
```
