### PR TITLE
Added Rule for Test-Naming convention

### DIFF
--- a/refarch-tools/refarch-java-tools/refarch-pmd/src/main/resources/refarch-pmd-ruleset.xml
+++ b/refarch-tools/refarch-java-tools/refarch-pmd/src/main/resources/refarch-pmd-ruleset.xml
@@ -35,12 +35,17 @@
     <rule ref="category/java/bestpractices.xml/UnitTestShouldIncludeAssert">
         <properties>
             <!-- From Spring WebTestClient -->
-            <property name="extraAssertMethodNames" value="expectStatus,expectHeader" />
+            <property name="extraAssertMethodNames" value="expectStatus,expectHeader,andExpect" />
         </properties>
     </rule>
     <rule ref="category/java/codestyle.xml/MethodNamingConventions">
         <properties>
             <property name="junit5TestPattern" value="[a-z]([a-zA-Z0-9]*[a-zA-Z]_?)*[a-zA-Z0-9]*" />
+        </properties>
+    </rule> 
+    <rule ref="category/java/codestyle.xml/CommentDefaultAccessModifier">
+        <properties>
+            <property name="ignoredAnnotations" value="android.support.annotation.VisibleForTesting,co.elastic.clients.util.VisibleForTesting,com.google.common.annotations.VisibleForTesting,org.junit.jupiter.api.AfterAll,org.junit.jupiter.api.AfterEach,org.junit.jupiter.api.BeforeAll,org.junit.jupiter.api.BeforeEach,org.junit.jupiter.api.RepeatedTest,org.junit.jupiter.api.Test,org.junit.jupiter.api.TestFactory,org.junit.jupiter.api.TestTemplate,org.junit.jupiter.api.extension.RegisterExtension,org.junit.jupiter.params.ParameterizedTest,org.testng.annotations.AfterClass,org.testng.annotations.AfterGroups,org.testng.annotations.AfterMethod,org.testng.annotations.AfterSuite,org.testng.annotations.AfterTest,org.testng.annotations.BeforeClass,org.testng.annotations.BeforeGroups,org.testng.annotations.BeforeMethod,org.testng.annotations.BeforeSuite,org.testng.annotations.BeforeTest,org.testng.annotations.Test,org.junit.jupiter.api.Nested" />
         </properties>
     </rule>     
 </ruleset>

--- a/refarch-tools/refarch-java-tools/refarch-pmd/src/main/resources/refarch-pmd-ruleset.xml
+++ b/refarch-tools/refarch-java-tools/refarch-pmd/src/main/resources/refarch-pmd-ruleset.xml
@@ -34,7 +34,7 @@
     </rule>
     <rule ref="category/java/bestpractices.xml/UnitTestShouldIncludeAssert">
         <properties>
-            <!-- From Spring WebTestClient -->
+            <!-- From Spring WebTestClient and MockMVC -->
             <property name="extraAssertMethodNames" value="expectStatus,expectHeader,andExpect" />
         </properties>
     </rule>

--- a/refarch-tools/refarch-java-tools/refarch-pmd/src/main/resources/refarch-pmd-ruleset.xml
+++ b/refarch-tools/refarch-java-tools/refarch-pmd/src/main/resources/refarch-pmd-ruleset.xml
@@ -38,4 +38,9 @@
             <property name="extraAssertMethodNames" value="expectStatus,expectHeader" />
         </properties>
     </rule>
+    <rule ref="category/java/codestyle.xml/MethodNamingConventions">
+        <properties>
+            <property name="junit5TestPattern" value="[a-z]([a-zA-Z0-9]*[a-zA-Z]_?)*[a-zA-Z0-9]*" />
+        </properties>
+    </rule>     
 </ruleset>


### PR DESCRIPTION
**Description**

- To use names like givenXXXX_thenXXX we need to modified the pmd-pattern for naming conventions
- added AndExpect for MockMVC to UnitTestShouldIncludeAssert
- added @Nested to CommentDefaultAccessModifier rule, to ignore modifier for nested methods

**Reference**

Part of the Pull Request https://github.com/it-at-m/refarch-templates/pull/349#discussion_r1802660186
