### PR TITLE
bug/s3-fix-missing-initial-con-test

### DIFF
--- a/refarch-integrations/refarch-s3-integration/README.md
+++ b/refarch-integrations/refarch-s3-integration/README.md
@@ -41,12 +41,13 @@ Whether a property is an alias can be checked in the corresponding `application.
 
 ### s3-integration-rest-service
 
-| Property                 | Description                                                    | Example                                       |
-|--------------------------|----------------------------------------------------------------|-----------------------------------------------|
-| `refarch.s3.url`         | Url of s3 endpoint to connect to.                              | `s3.example.com`                              |
-| `refarch.s3.bucket-name` | Name of the bucket to connect to.                              | `refarch-bucket`                              |
-| `refarch.s3.access-key`  | Access key to use for connection.                              |                                               |
-| `refarch.s3.secret-key`  | Secret key to use for connection.                              |                                               |
+| Property                                        | Description                       | Example          |
+|-------------------------------------------------|-----------------------------------|------------------|
+| `refarch.s3.url`                                | Url of s3 endpoint to connect to. | `s3.example.com` |
+| `refarch.s3.bucket-name`                        | Name of the bucket to connect to. | `refarch-bucket` |
+| `refarch.s3.access-key`                         | Access key to use for connection. |                  |
+| `refarch.s3.secret-key`                         | Secret key to use for connection. |                  |
+| `refarch.s3.initial-connection-test` (optional) | Test connection to s3 at startup  | `true` (default) |
 
 For authenticating the different endpoints oAuth2 authentication needs to be configured.
 See below example or the [according Spring documentation](https://docs.spring.io/spring-security/reference/servlet/oauth2/index.html#oauth2-resource-server).

--- a/refarch-integrations/refarch-s3-integration/refarch-s3-integration-starter/src/main/java/de/muenchen/refarch/integration/s3/properties/S3IntegrationProperties.java
+++ b/refarch-integrations/refarch-s3-integration/refarch-s3-integration-starter/src/main/java/de/muenchen/refarch/integration/s3/properties/S3IntegrationProperties.java
@@ -1,6 +1,7 @@
 package de.muenchen.refarch.integration.s3.properties;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -24,7 +25,8 @@ public class S3IntegrationProperties {
     @NotBlank
     private String bucketName;
 
-    private Boolean initialConnectionTest;
+    @NotNull
+    private Boolean initialConnectionTest = true;
 
     private int presignedUrlExpiresInMinutes = 7 * 24 * 60; // 7 days
 }


### PR DESCRIPTION
**Description**

Fix `refarch.s3.initial-connection-test` parameter missing for s3-rest-service.
- Set `true` by default
- Document

**Reference**

Issues closes #298
