### PR TITLE
:wrench: rm default Expires response header filter

### DIFF
--- a/refarch-gateway/src/main/resources/application.yml
+++ b/refarch-gateway/src/main/resources/application.yml
@@ -19,7 +19,6 @@ spring:
             allowedHeaders: "*"
             allowCredentials: true
       default-filters:
-        - RemoveResponseHeader=Expires
         - RemoveRequestHeader=cookie
         - RemoveRequestHeader=x-xsrf-token
         - TokenRelay=

--- a/refarch-gateway/src/test/java/de/muenchen/refarch/gateway/filter/GlobalAuthenticationErrorFilterTest.java
+++ b/refarch-gateway/src/test/java/de/muenchen/refarch/gateway/filter/GlobalAuthenticationErrorFilterTest.java
@@ -37,8 +37,7 @@ class GlobalAuthenticationErrorFilterTest {
                         .withStatus(HttpStatus.UNAUTHORIZED.value())
                         .withHeaders(new HttpHeaders(
                                 new HttpHeader("Content-Type", "application/json"),
-                                new HttpHeader("WWW-Authenticate", "Bearer realm=\"Access to the staging site\", charset=\"UTF-8\""),
-                                new HttpHeader("Expires", "Wed, 21 Oct 2099 07:28:06 GMT")))
+                                new HttpHeader("WWW-Authenticate", "Bearer realm=\"Access to the staging site\", charset=\"UTF-8\"")))
                         .withBody("{ \"testkey\" : \"testvalue\" }")));
     }
 
@@ -49,7 +48,6 @@ class GlobalAuthenticationErrorFilterTest {
                 .expectStatus().isEqualTo(HttpStatus.UNAUTHORIZED)
                 .expectHeader().valueMatches("Content-Type", "application/json")
                 .expectHeader().doesNotExist("WWW-Authenticate")
-                .expectHeader().valueMatches("Expires", "0")
                 .expectBody()
                 .jsonPath("$.status").isEqualTo("401")
                 .jsonPath("$.error").isEqualTo("Authentication Error");

--- a/refarch-gateway/src/test/java/de/muenchen/refarch/gateway/filter/GlobalBackend5xxTo400MapperTest.java
+++ b/refarch-gateway/src/test/java/de/muenchen/refarch/gateway/filter/GlobalBackend5xxTo400MapperTest.java
@@ -45,15 +45,13 @@ class GlobalBackend5xxTo400MapperTest {
                         .withHeaders(new HttpHeaders(
                                 new HttpHeader(org.springframework.http.HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType()),
                                 new HttpHeader(org.springframework.http.HttpHeaders.WWW_AUTHENTICATE,
-                                        "Bearer realm=\"Access to the staging site\", charset=\"UTF-8\""),
-                                new HttpHeader(org.springframework.http.HttpHeaders.EXPIRES, "Wed, 21 Oct 2099 07:28:06 GMT")))
+                                        "Bearer realm=\"Access to the staging site\", charset=\"UTF-8\"")))
                         .withBody("{ \"testkey\" : \"testvalue\" }")));
 
         webTestClient.get().uri("/api/refarch-gateway-backend-service/remote").exchange()
                 .expectStatus().isEqualTo(HttpStatus.BAD_REQUEST)
                 .expectHeader().valueMatches(org.springframework.http.HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
                 .expectHeader().doesNotExist(org.springframework.http.HttpHeaders.WWW_AUTHENTICATE)
-                .expectHeader().valueMatches(org.springframework.http.HttpHeaders.EXPIRES, "0")
                 .expectBody()
                 .jsonPath("$.status").isEqualTo("400")
                 .jsonPath("$.error").isEqualTo("Bad Request");
@@ -69,15 +67,13 @@ class GlobalBackend5xxTo400MapperTest {
                         .withHeaders(new HttpHeaders(
                                 new HttpHeader(org.springframework.http.HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType()),
                                 new HttpHeader(org.springframework.http.HttpHeaders.WWW_AUTHENTICATE,
-                                        "Bearer realm=\"Access to the staging site\", charset=\"UTF-8\""),
-                                new HttpHeader(org.springframework.http.HttpHeaders.EXPIRES, "Wed, 21 Oct 2099 07:28:06 GMT")))
+                                        "Bearer realm=\"Access to the staging site\", charset=\"UTF-8\"")))
                         .withBody("{ \"testkey\" : \"testvalue\" }")));
 
         webTestClient.get().uri("/api/refarch-gateway-backend-service/remote").exchange()
                 .expectStatus().isEqualTo(HttpStatus.OK)
                 .expectHeader().valueMatches(org.springframework.http.HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
                 .expectHeader().doesNotExist(org.springframework.http.HttpHeaders.WWW_AUTHENTICATE)
-                .expectHeader().valueMatches(org.springframework.http.HttpHeaders.EXPIRES, "0")
                 .expectBody()
                 .jsonPath("$.testkey").isEqualTo("testvalue");
     }

--- a/refarch-gateway/src/test/java/de/muenchen/refarch/gateway/filter/GlobalBackendErrorFilterTest.java
+++ b/refarch-gateway/src/test/java/de/muenchen/refarch/gateway/filter/GlobalBackendErrorFilterTest.java
@@ -43,8 +43,7 @@ class GlobalBackendErrorFilterTest {
                         .withStatus(HttpStatus.INTERNAL_SERVER_ERROR.value())
                         .withHeaders(new HttpHeaders(
                                 new HttpHeader("Content-Type", "application/json"),
-                                new HttpHeader("WWW-Authenticate", "Bearer realm=\"Access to the staging site\", charset=\"UTF-8\""),
-                                new HttpHeader("Expires", "Wed, 21 Oct 2099 07:28:06 GMT")))
+                                new HttpHeader("WWW-Authenticate", "Bearer realm=\"Access to the staging site\", charset=\"UTF-8\"")))
                         .withBody("{ \"testkey\" : \"testvalue\" }")));
     }
 
@@ -55,7 +54,6 @@ class GlobalBackendErrorFilterTest {
                 .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
                 .expectHeader().valueMatches("Content-Type", "application/json")
                 .expectHeader().doesNotExist("WWW-Authenticate")
-                .expectHeader().valueMatches("Expires", "0")
                 .expectBody()
                 .jsonPath("$.status").isEqualTo("500")
                 .jsonPath("$.error").isEqualTo("Internal Server Error");

--- a/refarch-gateway/src/test/java/de/muenchen/refarch/gateway/route/BackendRouteTest.java
+++ b/refarch-gateway/src/test/java/de/muenchen/refarch/gateway/route/BackendRouteTest.java
@@ -40,8 +40,7 @@ class BackendRouteTest {
                         .withHeaders(new HttpHeaders(
                                 new HttpHeader(org.springframework.http.HttpHeaders.CONTENT_TYPE, "application/json"),
                                 new HttpHeader(org.springframework.http.HttpHeaders.WWW_AUTHENTICATE,
-                                        "Bearer realm=\"Access to the staging site\", charset=\"UTF-8\""), // removed by route filter
-                                new HttpHeader(org.springframework.http.HttpHeaders.EXPIRES, "Wed, 21 Oct 2099 07:28:06 GMT") // removed by route filter
+                                        "Bearer realm=\"Access to the staging site\", charset=\"UTF-8\"") // removed by route filter
                         ))
                         .withBody("{ \"testkey\" : \"testvalue\" }")));
     }
@@ -58,7 +57,6 @@ class BackendRouteTest {
                 .expectStatus().isEqualTo(HttpStatus.OK)
                 .expectHeader().valueMatches(org.springframework.http.HttpHeaders.CONTENT_TYPE, "application/json")
                 .expectHeader().doesNotExist(org.springframework.http.HttpHeaders.WWW_AUTHENTICATE)
-                .expectHeader().valueMatches(org.springframework.http.HttpHeaders.EXPIRES, "0")
                 .expectBody().jsonPath("$.testkey").isEqualTo("testvalue");
 
         verify(getRequestedFor(urlEqualTo("/remote/endpoint"))


### PR DESCRIPTION
**Description**

Remove default-filter `RemoveResponseHeader=Expires` as it can lead to problems with applications.
- Seems to initially added when the frontend was delivered directly via Spring (which isn't the case anymore).
- It's not the responsibility of the gateway to remove the Expires header if a frontend/service sets it wrong.
- When setting up the refarch archetype there where problems between `Expires` and `Cache-Control`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The gateway will now retain the `Expires` header in responses, improving caching behavior for users.

- **Bug Fixes**
	- Resolved an issue where the `Expires` header was being stripped from responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->