### PR TITLE
:bug: gateway fix csrf property not settable

### DIFF
--- a/refarch-gateway/src/main/java/de/muenchen/refarch/gateway/configuration/CsrfProtectionMatcher.java
+++ b/refarch-gateway/src/main/java/de/muenchen/refarch/gateway/configuration/CsrfProtectionMatcher.java
@@ -1,5 +1,6 @@
 package de.muenchen.refarch.gateway.configuration;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -24,6 +25,7 @@ public class CsrfProtectionMatcher implements ServerWebExchangeMatcher {
     private static final Set<HttpMethod> ALLOWED_METHODS = new HashSet<>(
             Arrays.asList(HttpMethod.GET, HttpMethod.HEAD, HttpMethod.TRACE, HttpMethod.OPTIONS));
 
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
     private final SecurityProperties securityProperties;
 
     @Override

--- a/refarch-gateway/src/main/java/de/muenchen/refarch/gateway/configuration/SecurityProperties.java
+++ b/refarch-gateway/src/main/java/de/muenchen/refarch/gateway/configuration/SecurityProperties.java
@@ -1,14 +1,16 @@
 package de.muenchen.refarch.gateway.configuration;
 
 import java.util.List;
+import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Data
 @ConfigurationProperties("refarch.security")
 public class SecurityProperties {
     /**
      * List of url patterns excluded from csrf protection.
      */
-    private final List<String> csrfWhitelisted = List.of();
+    private List<String> csrfWhitelisted = List.of();
 
     public List<String> getCsrfWhitelisted() {
         return List.copyOf(this.csrfWhitelisted);

--- a/refarch-gateway/src/main/java/de/muenchen/refarch/gateway/configuration/SecurityProperties.java
+++ b/refarch-gateway/src/main/java/de/muenchen/refarch/gateway/configuration/SecurityProperties.java
@@ -1,5 +1,6 @@
 package de.muenchen.refarch.gateway.configuration;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -10,9 +11,6 @@ public class SecurityProperties {
     /**
      * List of url patterns excluded from csrf protection.
      */
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     private List<String> csrfWhitelisted = List.of();
-
-    public List<String> getCsrfWhitelisted() {
-        return List.copyOf(this.csrfWhitelisted);
-    }
 }


### PR DESCRIPTION
**Description**

Property can't be set via env var as Spring doesn't find setter.
Leads to error while startup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced security properties with a mutable CSRF whitelist for improved flexibility.
	- Added automatic generation of getter and setter methods for easier management of class fields.
	- Introduced annotations to suppress warnings related to mutable object exposure, ensuring better code safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->