### PR TITLE
:recycle: integrations refactor deprecated catchThrowableOfType

### DIFF
--- a/refarch-integrations/refarch-dms-integration/refarch-dms-integration-core/src/test/java/de/muenchen/refarch/integration/dms/application/usecase/ReadMetadataUseCaseTest.java
+++ b/refarch-integrations/refarch-dms-integration/refarch-dms-integration-core/src/test/java/de/muenchen/refarch/integration/dms/application/usecase/ReadMetadataUseCaseTest.java
@@ -44,7 +44,7 @@ class ReadMetadataUseCaseTest {
     void readMetadataThrowsDmsException() throws DmsException {
         when(this.readMetadataOutPort.readMetadata(any(), any())).thenReturn(new Metadata("name", "Ausgang", "url"));
 
-        final DmsException dmsException = catchThrowableOfType(() -> readMetadataUseCase.readMetadata(ObjectType.Sachakte, COO, USER), DmsException.class);
+        final DmsException dmsException = catchThrowableOfType(DmsException.class, () -> readMetadataUseCase.readMetadata(ObjectType.Sachakte, COO, USER));
 
         final String expectedMessage = String.format(
                 "WRONG_INPUT_OBJECT_CLASS: The input object with the COO address %s is invalid because it is of the object class %s and this does not match the expected object class(es) %s.",

--- a/refarch-integrations/refarch-email-integration/refarch-email-integration-core/src/test/java/de/muenchen/refarch/email/integration/application/usecase/SendMailUseCaseTest.java
+++ b/refarch-integrations/refarch-email-integration/refarch-email-integration-core/src/test/java/de/muenchen/refarch/email/integration/application/usecase/SendMailUseCaseTest.java
@@ -118,7 +118,7 @@ class SendMailUseCaseTest {
     @Test
     void sendMailWithTemplateThrowsIOException() throws TemplateException, IOException {
         doThrow(new IOException("IO Exception")).when(mailOutPort).getBodyFromTemplate(anyString(), anyMap());
-        final TemplateError error = catchThrowableOfType(() -> sendMailInPort.sendMailWithTemplate(templateMail), TemplateError.class);
+        final TemplateError error = catchThrowableOfType(TemplateError.class, () -> sendMailInPort.sendMailWithTemplate(templateMail));
 
         final String expectedMessage = "The template " + templateMail.getTemplate() + " could not be loaded";
         final String actualMessage = error.getMessage();
@@ -131,7 +131,7 @@ class SendMailUseCaseTest {
         final TemplateException templateException = mock(TemplateException.class);
         when(templateException.getMessage()).thenReturn("Template Exception Message");
         doThrow(templateException).when(mailOutPort).getBodyFromTemplate(anyString(), anyMap());
-        final TemplateError error = catchThrowableOfType(() -> sendMailInPort.sendMailWithTemplate(templateMail), TemplateError.class);
+        final TemplateError error = catchThrowableOfType(TemplateError.class, () -> sendMailInPort.sendMailWithTemplate(templateMail));
 
         final String expectedMessage = "Template Exception Message";
         final String actualMessage = error.getMessage();


### PR DESCRIPTION
**Description**

Refactor deprecated `catchThrowableOfType` to fix CodeQL warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved clarity in exception handling for metadata reading and email sending tests.
	- Updated syntax for catching exceptions in test cases for better readability.

- **Tests**
	- Enhanced exception assertion methods in `ReadMetadataUseCaseTest` and `SendMailUseCaseTest` for clearer intent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->