### PR TITLE
Revert "chore(deps): update softprops/action-gh-release action to v2.2.0"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,7 +84,7 @@ jobs:
     steps:
       - name: Create GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
           tag_name: "${{ inputs.module }}_${{ github.event.inputs.release-version }}"
           draft: false


### PR DESCRIPTION
Reverts it-at-m/refarch#327

See https://github.com/it-at-m/refarch-templates/pull/650#issuecomment-2548217782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new input parameters for the release process: `module`, `release-version`, and `next-version`.
	- Module selection now includes options for `refarch-gateway`, `refarch-integrations`, and `refarch-tools/refarch-java-tools`.

- **Improvements**
	- Updated action version for creating GitHub releases to enhance functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->