### PR TITLE
Maint/cleanup poms

### DIFF
--- a/refarch-gateway/pom.xml
+++ b/refarch-gateway/pom.xml
@@ -205,9 +205,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>${maven-release-plugin.version}</version>
-                <configuration>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/refarch-integrations/refarch-address-integration/refarch-address-integration-client/pom.xml
+++ b/refarch-integrations/refarch-address-integration/refarch-address-integration-client/pom.xml
@@ -44,10 +44,6 @@
 
         <!-- openApi -->
         <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
             <version>${jackson-databind-nullable.version}</version>
@@ -55,6 +51,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 
         <!-- Testing -->

--- a/refarch-integrations/refarch-cosys-integration/refarch-cosys-integration-client/pom.xml
+++ b/refarch-integrations/refarch-cosys-integration/refarch-cosys-integration-client/pom.xml
@@ -32,10 +32,6 @@
 
         <!-- openApi -->
         <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
             <version>${jackson-databind-nullable.version}</version>

--- a/refarch-integrations/refarch-dms-integration/refarch-dms-integration-fabasoft-rest-api/pom.xml
+++ b/refarch-integrations/refarch-dms-integration/refarch-dms-integration-fabasoft-rest-api/pom.xml
@@ -32,10 +32,6 @@
 
         <!-- openApi -->
         <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
             <version>${jackson-databind-nullable.version}</version>


### PR DESCRIPTION
**Description**

Cleanup poms:
- Rm gateway release-maven-plugin submodule configuration
- Rm integrations springdoc where not needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Updates**
  - Removed SpringDoc OpenAPI UI dependencies from multiple integration projects
  - Added Jackson date/time type support in address integration client
  - Removed Maven release plugin configuration in gateway project

<!-- end of auto-generated comment: release notes by coderabbit.ai -->