### PR TITLE
:wrench: renovate limit spotless version

### DIFF
--- a/refarch-tools/refarch-renovate/refarch-renovate-config.json5
+++ b/refarch-tools/refarch-renovate/refarch-renovate-config.json5
@@ -23,6 +23,12 @@
       "matchDatasources": ["maven"],
       "matchPackageNames": ["org.apache.camel.springboot:camel-spring-boot-dependencies"],
       "allowedVersions": "<=4.8"
+    },
+    {
+      "description": "Limit Spotless updates because greater versions break internal build (because of proxy). See https://github.com/it-at-m/refarch-templates/issues/16",
+      "matchDatasources": ["maven"],
+      "matchPackageNames": ["com.diffplug.spotless:spotless-maven-plugin"],
+      "allowedVersions": "<=2.34.0"
     }
   ]
 }


### PR DESCRIPTION
**Description**

Renovate limit spotless version, as higher version break internal build.
See issue https://github.com/it-at-m/refarch-templates/issues/16

