### PR TITLE
:memo: Added small information about bypass list for automerge

### DIFF
--- a/docs/templates/develop.md
+++ b/docs/templates/develop.md
@@ -216,6 +216,9 @@ For projects in the `it-at-m` organization, Renovate has access by default and i
 However, to finish the onboarding process of Renovate, you need to open a PR for a dependency update found by Renovate through the "Dependency Dashboard" issue.
 This PR then has to be merged manually once.
 After that's done Renovate will start opening PRs automatically.
+
+Also keep in mind Renovate needs to be able to bypass the [CODEOWNERS](#codeowners) requirements if you enabled that functionality inside your [ruleset](#github-rulesets).
+This can be achieved by adding the Renovate bot account to the [bypass list](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository#granting-bypass-permissions-for-your-branch-or-tag-ruleset).
 :::
 
 ## Pull Requests

--- a/docs/templates/develop.md
+++ b/docs/templates/develop.md
@@ -202,23 +202,8 @@ The configuration in the `application.yml` file (inside the `appswitcher-server`
 
 The templates by default make use of a centralized configuration we provide for RefArch-based projects. More information can be found in [Tools](../tools#renovate).
 
-To modify the default Renovate settings, the `renovate.json5` file in the project's root directory can be edited.
-
-::: info Information
-By default Renovate creates grouped PRs for dependency bumps. This means that if a particular dependency is found in multiple package manager files, the bump will be applied to all occurrences.
-If you want Renovate to create separate PRs by subfolder, add <code v-pre>"additionalBranchPrefix": "{{parentDir}}-"</code> to your Renovate configuration.
-Check the official [Renovate documentation](https://docs.renovatebot.com/configuration-options/#additionalbranchprefix) for further information and configuration options.
-:::
-
 ::: danger IMPORTANT
-To make Renovate work, make sure that it has access to your GitHub repository.
-For projects in the `it-at-m` organization, Renovate has access by default and is enabled when the configuration file is found in your repository.
-However, to finish the onboarding process of Renovate, you need to open a PR for a dependency update found by Renovate through the "Dependency Dashboard" issue.
-This PR then has to be merged manually once.
-After that's done Renovate will start opening PRs automatically.
-
-Also keep in mind Renovate needs to be able to bypass the [CODEOWNERS](#codeowners) requirements if you enabled that functionality inside your [ruleset](#github-rulesets).
-This can be achieved by adding the Renovate bot account to the [bypass list](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository#granting-bypass-permissions-for-your-branch-or-tag-ruleset).
+To make full use of the provided configuration additional setup is needed, so please check out the corresponding [Tools documentation](../tools#renovate).
 :::
 
 ## Pull Requests

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -45,11 +45,8 @@ See following example. The RefArch templates are already configured this way.
 
 The provided [Renovate](https://renovatebot.com) configuration [`refarch-renovate-config.json5`](https://github.com/it-at-m/refarch/blob/main/refarch-tools/refarch-renovate/refarch-renovate-config.json5) extends the [it@M global Renovate configurations](https://github.com/it-at-m/.github/tree/main/renovate-configs).
 Additionally, it includes specific presets for tagging and dependency restrictions to prevent Renovate from suggesting updates to dependencies that are pinned by RefArch.
-
-::: info Information
 The configuration also enables auto-merging of patch releases and pinning operations for GitHub Actions, NPM dependencies, Maven artifacts and Dockerfile base images while keeping pinning of dependencies intact.
-This greatly simplifies LCM effort.
-:::
+This greatly reduces LCM effort.
 
 The used presets from Renovate are described in the according [Renovate documentation](https://docs.renovatebot.com/presets-default/).
 
@@ -64,3 +61,18 @@ The file is included by default in the RefArch templates.
   ],
 }
 ```
+
+::: danger IMPORTANT
+To make Renovate work, make sure that it has access to your GitHub repository.
+For projects in the `it-at-m` organization, Renovate has access by default and is enabled when the configuration file is found in your repository.
+However, to finish the onboarding process of Renovate, you need to open a PR for a dependency update found by Renovate through the "Dependency Dashboard" issue.
+This PR then has to be merged manually once.
+After that's done Renovate will start opening PRs automatically.
+
+If you have configured [CODEOWNERS](./templates/develop#codeowners) for your project and require CODEOWNER approval inside your [ruleset](./templates/develop#github-rulesets),
+you need to configure bypass rules to make auto-merging possible.
+This can be achieved by adding the Renovate bot account to the [bypass list](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository#granting-bypass-permissions-for-your-branch-or-tag-ruleset).
+:::
+
+To modify the Renovate settings, the `renovate.json5` file can be edited.
+Check the official [Renovate documentation](https://docs.renovatebot.com/configuration-options/) for further information and configuration options.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -44,7 +44,7 @@ See following example. The RefArch templates are already configured this way.
 ## Renovate
 
 The provided [Renovate](https://renovatebot.com) configuration [`refarch-renovate-config.json5`](https://github.com/it-at-m/refarch/blob/main/refarch-tools/refarch-renovate/refarch-renovate-config.json5) extends the [it@M global Renovate configurations](https://github.com/it-at-m/.github/tree/main/renovate-configs).
-Additionally, it includes specific presets for tagging and dependency restrictions to prevent Renovate from suggesting updates to dependencies that are pinned by RefArch.
+Additionally, it includes specific presets for tagging and dependency restrictions to prevent Renovate from suggesting updates to dependencies that are pinned by the RefArch.
 The configuration also enables auto-merging of patch releases and pinning operations for GitHub Actions, NPM dependencies, Maven artifacts and Dockerfile base images while keeping pinning of dependencies intact.
 This greatly reduces LCM effort.
 


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[documentation-link]: https://refarch.oss.muenchen.de/templates/document.html#writing-the-documentation
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop.html#code-quality
[refarch-templates-create-issue-link]: https://github.com/it-at-m/refarch-templates/issues/new/choose

## Changes

- Added notice about bypass list for Renovate when used with CODEOWNERS

## Reference

Issue: #469

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] ~~I have read the Contribution Guidelines (TBD)~~
- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Created / Updated [documentation][documentation-link] (in English)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Simplified Renovate setup instructions in development documentation.
  - Added important prerequisites and warnings for Renovate operation, including GitHub access requirements and manual onboarding steps.
  - Provided guidance on configuring bypass rules for auto-merging Renovate PRs when approval rules are in place.
  - Included references to official Renovate and GitHub documentation for further configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->