### PR TITLE
feat(ci/release): add jars as github release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
     steps:
       - name: Create GitHub Release
         id: create_release
-        uses: it-at-m/lhm_actions/action-templates/actions/action-create-github-release@test/github-release-upload-fails
+        uses: it-at-m/lhm_actions/action-templates/actions/action-create-github-release@a7d25dbabec2057695f865169fdc411d475d4667 # v1.0.19
         with:
           tag-name: "${{ inputs.module }}_${{ github.event.inputs.release-version }}"
           generate-release-notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,9 +97,7 @@ jobs:
     steps:
       - name: Create GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        uses: it-at-m/lhm_actions/action-templates/actions/action-create-github-release@0f8ed45a5eb72bf1cc2fe1d3dbcbcfb852549c27 # v1.0.17
         with:
           tag_name: "${{ inputs.module }}_${{ github.event.inputs.release-version }}"
-          draft: false
-          prerelease: false
-          generate_release_notes: true
+          generate-release-notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
     steps:
       - name: Create GitHub Release
         id: create_release
-        uses: it-at-m/lhm_actions/action-templates/actions/action-create-github-release@a7d25dbabec2057695f865169fdc411d475d4667 # v1.0.19
+        uses: it-at-m/lhm_actions/action-templates/actions/action-create-github-release@test/github-release-upload-fails
         with:
           tag-name: "${{ inputs.module }}_${{ github.event.inputs.release-version }}"
           generate-release-notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,4 +102,4 @@ jobs:
           tag-name: "${{ inputs.module }}_${{ github.event.inputs.release-version }}"
           generate-release-notes: true
           artifact-name: ${{ needs.release-maven.outputs.ARTIFACT_NAME }}
-          artifact-path: "./**/target/*.jar"
+          artifact-path: "./refarch-gateway/target/*.jar"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
 
   create-github-release:
     if: ${{ !failure() && !cancelled() }}
-    needs: ["build-image-gateway", "build-images-integrations"]
+    needs: ["release-maven", "build-image-gateway", "build-images-integrations"]
     runs-on: ubuntu-latest
     steps:
       - name: Create GitHub Release
@@ -101,3 +101,5 @@ jobs:
         with:
           tag_name: "${{ inputs.module }}_${{ github.event.inputs.release-version }}"
           generate-release-notes: true
+          artifact-name: ${{ needs.release-maven.outputs.ARTIFACT_NAME }}
+          artifact-path: "./**/target/*.jar"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,4 +102,5 @@ jobs:
           tag-name: "${{ inputs.module }}_${{ github.event.inputs.release-version }}"
           generate-release-notes: true
           artifact-name: ${{ needs.release-maven.outputs.ARTIFACT_NAME }}
-          artifact-path: "./refarch-gateway/target/*.jar"
+          artifact-path: |
+            ./refarch-gateway/target/*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
         id: create_release
         uses: it-at-m/lhm_actions/action-templates/actions/action-create-github-release@0f8ed45a5eb72bf1cc2fe1d3dbcbcfb852549c27 # v1.0.17
         with:
-          tag_name: "${{ inputs.module }}_${{ github.event.inputs.release-version }}"
+          tag-name: "${{ inputs.module }}_${{ github.event.inputs.release-version }}"
           generate-release-notes: true
           artifact-name: ${{ needs.release-maven.outputs.ARTIFACT_NAME }}
           artifact-path: "./**/target/*.jar"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
     steps:
       - name: Create GitHub Release
         id: create_release
-        uses: it-at-m/lhm_actions/action-templates/actions/action-create-github-release@0f8ed45a5eb72bf1cc2fe1d3dbcbcfb852549c27 # v1.0.17
+        uses: it-at-m/lhm_actions/action-templates/actions/action-create-github-release@a7d25dbabec2057695f865169fdc411d475d4667 # v1.0.19
         with:
           tag-name: "${{ inputs.module }}_${{ github.event.inputs.release-version }}"
           generate-release-notes: true


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[documentation-link]: https://refarch.oss.muenchen.de/templates/document.html#writing-the-documentation
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop.html#code-quality
[refarch-templates-create-issue-link]: https://github.com/it-at-m/refarch-templates/issues/new/choose

## Changes

- release ci: use lhm_actions for github release
- release ci: add jars to github release

## Reference

Blocked by https://github.com/it-at-m/lhm_actions/pull/90

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Added meaningful PR title and list of changes in the description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the release workflow to improve integration with Maven artifacts and switched to a new GitHub Release action with revised input parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->