### PR TITLE
Maintenance: Downgrade Camel version limit to 4.10.x

### DIFF
--- a/refarch-tools/refarch-renovate/refarch-renovate-config.json5
+++ b/refarch-tools/refarch-renovate/refarch-renovate-config.json5
@@ -28,7 +28,7 @@
       "description": "Limit Camel updates to current LTS version (needs to be updated manually when new LTS release is out)",
       "matchManagers": ["maven"],
       "matchPackageNames": ["org.apache.camel.springboot:camel-spring-boot-dependencies"],
-      "allowedVersions": "<=4.11"
+      "allowedVersions": "<=4.10"
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[documentation-link]: https://refarch.oss.muenchen.de/templates/document.html#writing-the-documentation
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop.html#code-quality
[refarch-templates-create-issue-link]: https://github.com/it-at-m/refarch-templates/issues/new/choose

## Changes

- Downgraded Camel back to 4.10.x line as 4.11 is not a LTS release

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] ~~I have read the Contribution Guidelines (TBD)~~
- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management settings to restrict updates of "org.apache.camel.springboot:camel-spring-boot-dependencies" to versions up to 4.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->