### PR TITLE
chore(docs): provide information regarding VitePress base path (#714)

### DIFF
--- a/docs/templates/document.md
+++ b/docs/templates/document.md
@@ -67,5 +67,5 @@ To run this workflow, you must enable GitHub Pages for your repository and set t
 :::
 
 ::: info Information
-If your documentation is hosted under a repository sub path on GitHub Pages (e.g. `https://username.github.io/my-repo/`), make sure to set the `base` property in your VitePress `config.mts`. Without this, asset URLs may point to the root path and result in 404 errors.
+If your documentation is hosted under a sub path (e.g. on GitHub Pages `https://username.github.io/my-repo/`), make sure to set the `base` property in your VitePress `config.mts`. Without this, asset URLs may point to the root path and result in 404 errors.
 :::


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[documentation-link]: https://refarch.oss.muenchen.de/templates/document.html#writing-the-documentation
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop.html#code-quality
[refarch-templates-create-issue-link]: https://github.com/it-at-m/refarch-templates/issues/new/choose

## Changes

- Added brief information regarding VitePress base path

## Reference

Issue: #714
Related PR in refarch-templates: [#1312](https://github.com/it-at-m/refarch-templates/pull/1312)

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] ~~I have read the Contribution Guidelines (TBD)~~
- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Created / Updated [documentation][documentation-link] (in English)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an informational note to the docs advising users who host documentation under a subpath (e.g., GitHub Pages subdirectory) to set the site base in their VitePress configuration to avoid 404s when deploying to a subdirectory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->