### PR TITLE
:bug: Fix renovate configuration to ignore spring updates in eai project

### DIFF
--- a/refarch-tools/refarch-renovate/refarch-renovate-config.json5
+++ b/refarch-tools/refarch-renovate/refarch-renovate-config.json5
@@ -24,7 +24,7 @@
       "description": "Ignore spring-boot-parent updates in EAI projects because Camel version specifies compatible Spring version",
       "matchManagers": ["maven"],
       "matchPackageNames": ["org.springframework.boot:spring-boot-starter-parent"],
-      "matchFileNames": ["**/*-eai/pom.xml"],
+      "matchFileNames": ["**/*eai/pom.xml"],
       "enabled": false
     },
     {


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[documentation-link]: https://refarch.oss.muenchen.de/templates/document.html#writing-the-documentation
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop.html#code-quality
[refarch-templates-create-issue-link]: https://github.com/it-at-m/refarch-templates/issues/new/choose

## Changes

- Fix renovate refarch config to ignore Spring updates in EAI projects (error introduced by renaming of template folders)

### General

- [x] Added meaningful PR title and list of changes in the description

### Code

- [x] Wrote code and comments in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Refined dependency update automation configuration to adjust which project directories are targeted for Spring Boot Maven dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->