### PR TITLE
ci(release): rm deprecated integrations s3 service

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,32 +70,9 @@ jobs:
             type=raw,value=${{ inputs.release-version }}
             type=raw,value=latest,enable=${{ inputs.tag-latest == true }}
 
-  release-image-integrations:
-    if: inputs.module == 'refarch-integrations'
-    needs: release-maven
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    strategy:
-      matrix:
-        include:
-          - name: s3-integration-rest-service
-            path: ./refarch-integrations/refarch-s3-integration/refarch-s3-integration-rest/refarch-s3-integration-rest-service
-    steps:
-      - uses: it-at-m/lhm_actions/action-templates/actions/action-build-image@94f7e40aa557a2790abfa98a9cc9186d260b94f8 # v1.0.27
-        with:
-          registry-username: ${{ github.actor }}
-          registry-password: ${{ secrets.GITHUB_TOKEN }}
-          path: ${{ matrix.path }}
-          artifact-name: ${{ needs.release-maven.outputs.ARTIFACT_NAME }}
-          image-name: ${{ matrix.name }}
-          image-tags: |
-            type=raw,value=${{ inputs.release-version }}
-            type=raw,value=latest,enable=${{ inputs.tag-latest == true }}
-
   release-github:
     if: ${{ !failure() && !cancelled() }}
-    needs: ["release-maven", "release-image-gateway", "release-image-integrations"]
+    needs: ["release-maven", "release-image-gateway"]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[documentation-link]: https://refarch.oss.muenchen.de/templates/document.html#writing-the-documentation
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop.html#code-quality
[refarch-templates-create-issue-link]: https://github.com/it-at-m/refarch-templates/issues/new/choose

## Changes

- ci: fix release workflow by removing no more existing s3 integration service

## Reference

PR: https://github.com/it-at-m/refarch/pull/742

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Added meaningful PR title and list of changes in the description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Simplified the release pipeline by streamlining deployment operations and removing an unused image build step from automated releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->