### PR TITLE
chore(refarch-gateway): restrict default cors config

### DIFF
--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -29,6 +29,9 @@ The gateway then maps the session cookie to a JWT before routing it.
 
 Beside the default behavior there are special public and client routes described in the following.
 
+CORS is denied by default.
+Only configure CORS if browser-based cross-origin access is explicitly required.
+
 #### Public Routes
 
 Requests matching public routes are routed **WITHOUT** authentication.
@@ -76,10 +79,30 @@ refarch:
     client-patterns: # Additional client routes (optional)
       - /example/**
 
-# Aliases for `spring.cloud.gateway.server.webflux.globalcors.cors-configurations` to allow configuration via environment variables, as the used glob patterns can't be used there
-ALLOWED_ORIGINS_PUBLIC: https://*.example.com,http://localhost:* # List of URIs allowed as origin for public routes (optional)
-ALLOWED_ORIGINS_CLIENTS: https://*.example.com,http://localhost:* # List of URIs allowed as origin for client routes (optional)
+# Aliases for `spring.cloud.gateway.server.webflux.globalcors.cors-configurations` to allow configuration via environment variables, as the used glob patterns can't be used there.
+# Restrictive defaults intentionally deny CORS unless it is configured explicitly.
+ALLOWED_ORIGINS_ALL: "" # Default origins for all routes, especially everything except /public/** and /clients/**
+ALLOWED_HEADERS_ALL: "" # Default allowed CORS request headers for all routes
+ALLOW_CREDENTIALS_ALL: false # Default credential handling for all routes
+ALLOWED_METHODS_ALL: GET # Default allowed CORS methods for all routes
+ALLOWED_ORIGINS_PUBLIC: https://*.example.com,http://localhost:* # Optional override for /public/**
+ALLOWED_HEADERS_PUBLIC: Content-Type # Optional override for /public/**
+ALLOW_CREDENTIALS_PUBLIC: false # Optional override for /public/**
+ALLOWED_METHODS_PUBLIC: GET,POST # Optional override for /public/**
+ALLOWED_ORIGINS_CLIENTS: https://*.example.com,http://localhost:* # Optional override for /clients/**
+ALLOWED_HEADERS_CLIENTS: Authorization,Content-Type,X-XSRF-TOKEN # Optional override for /clients/**
+ALLOW_CREDENTIALS_CLIENTS: true # Optional override for /clients/**
+ALLOWED_METHODS_CLIENTS: GET,POST,PUT,PATCH,DELETE,OPTIONS # Optional override for /clients/**
 ```
+
+The gateway ships three CORS buckets:
+
+- `/**` as restrictive default for all endpoints
+- `/public/**` as optional override for public endpoints
+- `/clients/**` as optional override for client endpoints
+
+Because `/public/**` and `/clients/**` are more specific, they override `/**` for those routes.
+All other endpoints use the restrictive `/**` configuration.
 
 ### Security
 

--- a/docs/support/known-issues.md
+++ b/docs/support/known-issues.md
@@ -11,8 +11,8 @@ If not feel free to open a new one.
 
 ### "Origin not allowed" but configured
 
-By providing default CORS configuration for `/public/**` and `/clients/**` routes (to support configuration via environment variables),
-this default one can take precedence over custom configuration.
+By providing default CORS configuration for `/**`, `/public/**` and `/clients/**` routes (to support configuration via environment variables),
+the more specific defaults can take precedence over custom configuration.
 This leads to deployment specific configuration (setting e.g. `/**`) not being applied for `/public/**` and `/clients/**` routes.
 
 To fix that, set CORS for the keys `/public/**` and/or `/clients/**` or use the according environment variables.

--- a/refarch-gateway/src/main/resources/application.yml
+++ b/refarch-gateway/src/main/resources/application.yml
@@ -12,13 +12,21 @@ spring:
         webflux:
           globalcors:
             cors-configurations:
+              '[/**]':
+                allowedOriginPatterns: ${ALLOWED_ORIGINS_ALL:}
+                allowedHeaders: ${ALLOWED_HEADERS_ALL:}
+                allowCredentials: ${ALLOW_CREDENTIALS_ALL:false}
+                allowedMethods: ${ALLOWED_METHODS_ALL:GET}
               '[/public/**]':
-                allowedOriginPatterns: ${ALLOWED_ORIGINS_PUBLIC}
+                allowedOriginPatterns: ${ALLOWED_ORIGINS_PUBLIC:${ALLOWED_ORIGINS_ALL:}}
+                allowedHeaders: ${ALLOWED_HEADERS_PUBLIC:${ALLOWED_HEADERS_ALL:}}
+                allowCredentials: ${ALLOW_CREDENTIALS_PUBLIC:${ALLOW_CREDENTIALS_ALL:false}}
+                allowedMethods: ${ALLOWED_METHODS_PUBLIC:${ALLOWED_METHODS_ALL:GET}}
               '[/clients/**]':
-                allowedOriginPatterns: ${ALLOWED_ORIGINS_CLIENTS}
-                allowedHeaders: "*"
-                allowCredentials: true
-                allowedMethods: "*"
+                allowedOriginPatterns: ${ALLOWED_ORIGINS_CLIENTS:${ALLOWED_ORIGINS_ALL:}}
+                allowedHeaders: ${ALLOWED_HEADERS_CLIENTS:${ALLOWED_HEADERS_ALL:}}
+                allowCredentials: ${ALLOW_CREDENTIALS_CLIENTS:${ALLOW_CREDENTIALS_ALL:false}}
+                allowedMethods: ${ALLOWED_METHODS_CLIENTS:${ALLOWED_METHODS_ALL:GET}}
           default-filters:
             - RemoveRequestHeader=cookie
             - RemoveRequestHeader=x-xsrf-token


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[documentation-link]: https://refarch.oss.muenchen.de/templates/document.html#writing-the-documentation
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop.html#code-quality

## Changes

- add a restrictive global CORS default for all routes so cross-origin access is denied unless configured explicitly
- make global, public and client CORS settings centrally overridable via environment variables with inherited defaults
- document the new CORS defaults, override precedence and broader default scope in gateway docs and known issues

## Reference

Issue: [#internal&66](https://git.muenchen.de/ccse/refarch/refarch-internal/-/work_items/66)

## Checklist

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Created / Updated [documentation][documentation-link] (in English)

### Code

- [x] Wrote code and comments in English
- [x] Removed waste on branch (for example console.log), see [code quality tooling][code-quality-link]