### PR TITLE
:recycle: Remove deprecations for @Valid on collection level

### DIFF
--- a/refarch-gateway/src/main/java/de/muenchen/oss/refarch/gateway/configuration/SecurityProperties.java
+++ b/refarch-gateway/src/main/java/de/muenchen/oss/refarch/gateway/configuration/SecurityProperties.java
@@ -35,7 +35,7 @@ public class SecurityProperties {
      * All methods must be explicitly listed, there is no implicit "all".
      * WARNING: Authentication is DISABLED for matching requests.
      */
-    @Valid @NotNull private List<@NotNull PermitRule> publicPatterns = List.of();
+    @NotNull private List<@Valid @NotNull PermitRule> publicPatterns = List.of();
 
     /**
      * Rule describing a public endpoint combination consisting of a path pattern and the explicitly


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[documentation-link]: https://refarch.oss.muenchen.de/templates/document.html#writing-the-documentation
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop.html#code-quality
[refarch-templates-create-issue-link]: https://github.com/it-at-m/refarch-templates/issues/new/choose

## Changes

- Fixed @Valid deprecated usage, see https://docs.hibernate.org/validator/9.1/whats-new/en-US/html_single/#_deprecating_the_use_of_valid_at_the_container_level

Note that still some warnings occur due to Spring internals:
```text
HV000271: Using `@Valid` on a container (java.util.List) is deprecated. You should apply the annotation on the type argument(s). Affected element: routes
HV000271: Using `@Valid` on a container (java.util.List) is deprecated. You should apply the annotation on the type argument(s). Affected element: filters
HV000271: Using `@Valid` on a container (java.util.List) is deprecated. You should apply the annotation on the type argument(s). Affected element: predicates
```

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description

### Code

- [x] Wrote code and comments in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of configured public access rules.
  * Ensured each access rule is individually checked for validity and required values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->