### PR TITLE
feat(integrations/s3): configurable timeouts

### DIFF
--- a/docs/integrations/s3.md
+++ b/docs/integrations/s3.md
@@ -33,6 +33,6 @@ After that the [S3OutPort](https://github.com/it-at-m/refarch/blob/main/refarch-
 | `refarch.s3.access-key`                           | Access key to use for connection.                     |                       |
 | `refarch.s3.secret-key`                           | Secret key to use for connection.                     |                       |
 | `refarch.s3.connection-timeout`                   | Timeout for establishing connection.                  | `30s` (default)       |
-| `refarch.s3.socket-timeout`                       | Timeout for data being transfered over connection.    | `60s` (default)       |
+| `refarch.s3.socket-timeout`                       | Timeout for data being transferred over connection.   | `60s` (default)       |
 | `refarch.s3.path-style-access-enabled` (optional) | If bucket is specified via path (subdomain if false). | `true` (default)      |
 | `refarch.s3.initial-connection-test` (optional)   | Test connection to S3 at startup.                     | `true` (default)      |

--- a/docs/integrations/s3.md
+++ b/docs/integrations/s3.md
@@ -32,5 +32,7 @@ After that the [S3OutPort](https://github.com/it-at-m/refarch/blob/main/refarch-
 | `refarch.s3.region` (optional)                    | Region to use for the connection.                     | `us-east-1` (default) |
 | `refarch.s3.access-key`                           | Access key to use for connection.                     |                       |
 | `refarch.s3.secret-key`                           | Secret key to use for connection.                     |                       |
+| `refarch.s3.connection-timeout`                   | Timeout for establishing connection.                  | `30s` (default)       |
+| `refarch.s3.socket-timeout`                       | Timeout for data being transfered over connection.    | `60s` (default)       |
 | `refarch.s3.path-style-access-enabled` (optional) | If bucket is specified via path (subdomain if false). | `true` (default)      |
 | `refarch.s3.initial-connection-test` (optional)   | Test connection to S3 at startup.                     | `true` (default)      |

--- a/refarch-integrations/refarch-s3-integration/refarch-s3-integration-core/pom.xml
+++ b/refarch-integrations/refarch-s3-integration/refarch-s3-integration-core/pom.xml
@@ -16,6 +16,18 @@
         <awssdk.version>2.46.21</awssdk.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${awssdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Spring -->
         <dependency>
@@ -34,22 +46,16 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
-            <version>${awssdk.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>software.amazon.awssdk</groupId>
                     <artifactId>netty-nio-client</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>software.amazon.awssdk</groupId>
-                    <artifactId>apache5-client</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>url-connection-client</artifactId>
-            <version>${awssdk.version}</version>
+            <artifactId>apache-client</artifactId>
         </dependency>
 
         <!-- Testing -->

--- a/refarch-integrations/refarch-s3-integration/refarch-s3-integration-starter/src/main/java/de/muenchen/oss/refarch/integration/s3/configuration/S3IntegrationAutoConfiguration.java
+++ b/refarch-integrations/refarch-s3-integration/refarch-s3-integration-starter/src/main/java/de/muenchen/oss/refarch/integration/s3/configuration/S3IntegrationAutoConfiguration.java
@@ -5,6 +5,7 @@ import de.muenchen.oss.refarch.integration.s3.adapter.out.s3.S3OutAdapter;
 import de.muenchen.oss.refarch.integration.s3.application.port.out.S3OutPort;
 import de.muenchen.oss.refarch.integration.s3.properties.S3IntegrationProperties;
 import java.net.URI;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -14,6 +15,8 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -40,7 +43,12 @@ public class S3IntegrationAutoConfiguration {
                         s3IntegrationProperties.getAccessKey(),
                         s3IntegrationProperties.getSecretKey()));
 
+        final SdkHttpClient.Builder<ApacheHttpClient.Builder> httpClient = ApacheHttpClient.builder()
+                .connectionTimeout(s3IntegrationProperties.getConnectionTimeout())
+                .socketTimeout(s3IntegrationProperties.getSocketTimeout());
+
         final S3Client client = S3Client.builder()
+                .httpClientBuilder(httpClient)
                 .endpointOverride(URI.create(s3IntegrationProperties.getUrl()))
                 .region(Region.of(s3IntegrationProperties.getRegion()))
                 .credentialsProvider(creds)

--- a/refarch-integrations/refarch-s3-integration/refarch-s3-integration-starter/src/main/java/de/muenchen/oss/refarch/integration/s3/properties/S3IntegrationProperties.java
+++ b/refarch-integrations/refarch-s3-integration/refarch-s3-integration-starter/src/main/java/de/muenchen/oss/refarch/integration/s3/properties/S3IntegrationProperties.java
@@ -50,7 +50,8 @@ public class S3IntegrationProperties {
     @NotNull private Duration connectionTimeout = Duration.ofSeconds(30);
 
     /**
-     * The amount of time to wait for data to be transferred over an established, open connection before timing out.
+     * The amount of time to wait for data to be transferred over an established, open connection before
+     * timing out.
      */
     @DurationMin(seconds = 1)
     @NotNull private Duration socketTimeout = Duration.ofSeconds(60);

--- a/refarch-integrations/refarch-s3-integration/refarch-s3-integration-starter/src/main/java/de/muenchen/oss/refarch/integration/s3/properties/S3IntegrationProperties.java
+++ b/refarch-integrations/refarch-s3-integration/refarch-s3-integration-starter/src/main/java/de/muenchen/oss/refarch/integration/s3/properties/S3IntegrationProperties.java
@@ -1,8 +1,11 @@
 package de.muenchen.oss.refarch.integration.s3.properties;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -39,6 +42,18 @@ public class S3IntegrationProperties {
      * Must not be blank. Avoid logging or exposing this value.
      */
     @NotBlank private String secretKey;
+
+    /**
+     * The amount of time to wait when establishing a connection to S3 before timing out.
+     */
+    @DurationMin(seconds = 1)
+    @NotNull private Duration connectionTimeout = Duration.ofSeconds(30);
+
+    /**
+     * The amount of time to wait for data to be transferred over an established, open connection before timing out.
+     */
+    @DurationMin(seconds = 1)
+    @NotNull private Duration socketTimeout = Duration.ofSeconds(60);
 
     /**
      * Whether to use path-style access (e.g., http://endpoint/bucket/object) instead of


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[documentation-link]: https://refarch.oss.muenchen.de/templates/document.html#writing-the-documentation
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop.html#code-quality
[refarch-templates-create-issue-link]: https://github.com/it-at-m/refarch-templates/issues/new/choose

## Changes

- feat(integrations/s3): allow to configure connection and socket timeout and apply defaults
- refact(integrations/s3): switch from url-connection-client to apache client

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Added meaningful PR title and list of changes in the description
- [x] Created / Updated [documentation][documentation-link] (in English)

### Code

- [x] Wrote code and comments in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable S3 connection and data transfer timeouts.
  * Set default timeouts to 30 seconds for establishing connections and 60 seconds for socket communication.
  * Added validation to ensure timeout values are positive.

* **Documentation**
  * Documented the new S3 timeout configuration properties and their default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->