### PR TITLE
Maintenance: Switch to multi-architecture SHA base image for refarch-gateway

### DIFF
--- a/docs/templates/deploy.md
+++ b/docs/templates/deploy.md
@@ -10,7 +10,7 @@ All templates include a simple `Dockerfile` to build Docker images. The followin
 - JavaScript-based templates (`frontend` and `webcomponent`): RedHat UBI Nginx (e.g. [`ubi10/nginx-126`](https://catalog.redhat.com/en/software/containers/ubi10/nginx-126/677d3735607921b4d7503cf3))
 
 ::: danger Important
-It is strongly recommended to use a multi-architecture base image whenever possible. In such cases, an architecture-agnostic SHA should be used.
+To ensure broad hardware compatibility of built container images it is strongly recommended to use a multi-architecture base image whenever possible. In such cases, an architecture-agnostic SHA should be used.
 Depending on the image source, the correct SHA can be found for:
 
 - **RedHat Image Catalog**: Check "Get this image -> Image identifiers -> Manifest List Digest" on the image page

--- a/docs/templates/deploy.md
+++ b/docs/templates/deploy.md
@@ -6,7 +6,7 @@ The templates include configuration files to simplify deployment of applications
 
 All templates include a simple `Dockerfile` to build Docker images. The following base images are used:
 
-- Java-based templates (`backend` and `eai`): [RedHat UBI OpenJDK Runtime](https://rh-openjdk.github.io/redhat-openjdk-containers/index.html)
+- Java-based templates (`backend` and `eai`): [RedHat UBI OpenJDK Runtime](https://rh-openjdk.github.io/redhat-openjdk-containers/)
 - JavaScript-based templates (`frontend` and `webcomponent`): RedHat UBI Nginx (e.g. [`ubi10/nginx-126`](https://catalog.redhat.com/en/software/containers/ubi10/nginx-126/677d3735607921b4d7503cf3))
 
 ::: danger Important

--- a/docs/templates/deploy.md
+++ b/docs/templates/deploy.md
@@ -10,7 +10,7 @@ All templates include a simple `Dockerfile` to build Docker images. The followin
 - JavaScript-based templates (`frontend` and `webcomponent`): RedHat UBI Nginx (e.g. [`ubi10/nginx-126`](https://catalog.redhat.com/en/software/containers/ubi10/nginx-126/677d3735607921b4d7503cf3))
 
 ::: danger Important
-To ensure broad hardware compatibility of built container images it is strongly recommended to use a multi-architecture base image whenever possible. In such cases, an architecture-agnostic SHA should be used.
+To ensure broad hardware compatibility of built container images, it is strongly recommended to use a multi-architecture base image whenever possible. In such cases, an architecture-agnostic SHA should be used.
 Depending on the image source, the correct SHA can be found for:
 
 - **RedHat Image Catalog**: Check "Get this image -> Image identifiers -> Manifest List Digest" on the image page

--- a/docs/templates/deploy.md
+++ b/docs/templates/deploy.md
@@ -12,10 +12,11 @@ All templates include a simple `Dockerfile` to build Docker images. The followin
 ::: danger Important
 It is strongly recommended to use a multi-architecture base image whenever possible. In such cases, an architecture-agnostic SHA should be used.
 Depending on the image source, the correct SHA can be found for:
+
 - **RedHat Image Catalog**: Check "Get this image -> Image identifiers -> Manifest List Digest" on the image page
 - **GitHub**: Use SHA at the top directly underneath the tag name, not the SHA listed in "OS/Arch"
 - **DockerHub**: Use "Index Digest", not "Manifest Digest"
-:::
+  :::
 
 ## Helm Chart
 

--- a/docs/templates/deploy.md
+++ b/docs/templates/deploy.md
@@ -9,6 +9,14 @@ All templates include a simple `Dockerfile` to build Docker images. The followin
 - Java-based templates (`backend` and `eai`): [RedHat UBI OpenJDK Runtime](https://rh-openjdk.github.io/redhat-openjdk-containers/index.html)
 - JavaScript-based templates (`frontend` and `webcomponent`): RedHat UBI Nginx (e.g. [`ubi10/nginx-126`](https://catalog.redhat.com/en/software/containers/ubi10/nginx-126/677d3735607921b4d7503cf3))
 
+::: danger Important
+It is strongly recommended to use a multi-architecture base image whenever possible. In such cases, an architecture-agnostic SHA should be used.
+Depending on the image source, the correct SHA can be found for:
+- **RedHat Image Catalog**: Check "Get this image -> Image identifiers -> Manifest List Digest" on the image page
+- **GitHub**: Use SHA at the top directly underneath the tag name, not the SHA listed in "OS/Arch"
+- **DockerHub**: Use "Index Digest", not "Manifest Digest"
+:::
+
 ## Helm Chart
 
 [Helm](https://helm.sh/) allows easy deployment of multi-container applications to a Kubernetes cluster using charts.

--- a/refarch-gateway/Dockerfile
+++ b/refarch-gateway/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-11@sha256:0adb5132beb506b62fc15d86619a761868003506e0e2b5b6ca9ba82be519ca64
+FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-11@sha256:2056c5139666c5e52f01af5b80f0def423a94c3fe824321d74041c11e20c9b72
 
 COPY target/*.jar /deployments/spring-boot-application.jar

--- a/refarch-gateway/Dockerfile
+++ b/refarch-gateway/Dockerfile
@@ -1,3 +1,4 @@
+# Note: For base images an architecture-agnostic SHA is always preferred, see https://refarch.oss.muenchen.de/templates/deploy.html#docker-images for more info.
 FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-11@sha256:2056c5139666c5e52f01af5b80f0def423a94c3fe824321d74041c11e20c9b72
 
 COPY target/*.jar /deployments/spring-boot-application.jar

--- a/refarch-gateway/Dockerfile
+++ b/refarch-gateway/Dockerfile
@@ -1,4 +1,7 @@
 # Note: For base images an architecture-agnostic SHA is always preferred, see https://refarch.oss.muenchen.de/templates/deploy.html#docker-images for more info.
+
+# For documentation see https://rh-openjdk.github.io/redhat-openjdk-containers/
 FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-11@sha256:2056c5139666c5e52f01af5b80f0def423a94c3fe824321d74041c11e20c9b72
 
-COPY target/*.jar /deployments/spring-boot-application.jar
+# Copy runnable jar to deployments
+COPY target/*.jar /deployments/application.jar


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[documentation-link]: https://refarch.oss.muenchen.de/templates/document.html#writing-the-documentation
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop.html#code-quality
[refarch-templates-create-issue-link]: https://github.com/it-at-m/refarch-templates/issues/new/choose

## Changes

- Changed SHA in Dockerfile to architecture-agnostic SHA
- Added docs for deploy section about mulit-arch base images

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Created / Updated [documentation][documentation-link] (in English)
- [x] Opened follow-up issue in https://github.com/it-at-m/refarch-templates/pull/1795

### Code

- [x] Wrote code and comments in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added deployment guidance for selecting multi-architecture Docker base images and architecture-agnostic image digests.
  - Included source-specific instructions for finding verified image digests.

- **Bug Fixes**
  - Updated the gateway’s pinned OpenJDK 21 runtime image to a current architecture-agnostic digest.
  - Added clarification about architecture compatibility for the base image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->